### PR TITLE
Remove bundle suffix in Fixel_AFD process

### DIFF
--- a/main.nf
+++ b/main.nf
@@ -114,6 +114,7 @@ process Fixel_AFD {
         else
             bname=\$(basename \$bundle .trk)
         fi
+        bname=\${bname/$params.bundle_suffix_to_remove/}
         scil_compute_mean_fixel_afd_from_bundles.py \$bundle $fodf \${bname}_afd_metric.nii.gz
     done
     """


### PR DESCRIPTION
- Bundle suffix was not removed in Fixel_AFD, leading to AFD output filenames with the suffix, (e.g. "UF_R_m_cleaned_afd_metric.nii.gz"). Consequently, the following processes cannot match bundle names between .trk files and AFD Nifti files. For example, "Bundle_Endpoints_Metrics" computes the cross product of all bundles with all bundle_afd_metrics instead of matching each bundle with its afd metric.