### PR TITLE
Compute fixel MRDS metrics along bundles

### DIFF
--- a/USAGE
+++ b/USAGE
@@ -15,7 +15,10 @@ DESCRIPTION
                             ├── S1
                             │   ├── *lesion_mask.nii.gz (optional)
                             │   ├── *fodf.nii.gz (optional to generate fixel AFD)
+                            │   ├── *pdds.nii.gz (optional to generate fixel FA,MD,RD,AD)
                             │   ├── metrics
+                            │   │   └── *.nii.gz
+                            │   ├── fixel_metrics
                             │   │   └── *.nii.gz
                             │   └── bundles
                             │       └── *.trk
@@ -23,6 +26,8 @@ DESCRIPTION
                                 ├── *lesion_mask.nii.gz (optional)
                                 ├── *fodf.nii.gz (optional to generate fixel AFD)
                                 ├── metrics
+                                │   └── *.nii.gz
+                                ├── fixel_metrics
                                 │   └── *.nii.gz
                                 └── bundles
                                     └── *.trk
@@ -37,12 +42,16 @@ DESCRIPTION
                             ├── S1
                             │   ├── metrics
                             │   │   └── *.nii.gz
+                            │   ├── fixel_metrics
+                            │   │   └── *.nii.gz
                             │   ├── centroids
                             │   │   └── [Bundle_Name]_centroid.trk
                             │   └── bundles
                             │       └── [Bundle_Name].trk
                             └── S2
                                 ├── metrics
+                                │   └── *.nii.gz
+                                ├── fixel_metrics
                                 │   └── *.nii.gz
                                 ├── centroids
                                 │   └── [Bundle_Name]_centroid.trk
@@ -72,6 +81,7 @@ OPTIONAL ARGUMENTS (current value)
 --mean_std_per_point_density_weighting      Weight the mean/std per point by the local tract density ($mean_std_per_point_density_weighting)
 --endpoints_metric_stats_normalize_weights  Normalize the weights to the [0, 1] range ($endpoints_metric_stats_normalize_weights)
 --skip_projection_endpoints_metrics         Skip the (slow) process that projects metrics onto the endpoints of streamlines  ($skip_projection_endpoints_metrics)
+--compute_fixel_mrds_metrics                Compute fixel-based multi-tensor MRDS metrics along the bundles ($compute_fixel_mrds_metrics)
 
 --processes                                 The number of parallel processes to launch ($cpu_count).
                                             Only affects the local scheduler.

--- a/nextflow.config
+++ b/nextflow.config
@@ -18,6 +18,7 @@ params {
     use_provided_centroids=true
     skip_projection_endpoints_metrics=true
     bundle_suffix_to_remove='_cleaned'
+    compute_fixel_mrds_metrics=false
 
     colors=["AC":"0x02d983",
             "AF_L":"0xcc0000",


### PR DESCRIPTION
- Add new process Fixel_MRDS to compute the fixel-based multi-tensor metrics along each input bundle. 
- Update input tree to include input MRDS files

Tested with scilpy-v1.6 and scilpy-v1.7-dev. It works with v1.6 but crashes with v1.7-dev.

TODO

- [ ] Test it with new scilpy-v2.0